### PR TITLE
Read chronos url from properties file.

### DIFF
--- a/JobProxyChronos/src/main/java/de/unibi/cebitec/bibiserv/jobproxy/chronos/Chronos.java
+++ b/JobProxyChronos/src/main/java/de/unibi/cebitec/bibiserv/jobproxy/chronos/Chronos.java
@@ -96,7 +96,7 @@ public class Chronos extends JobProxyInterface {
     public Chronos(Properties properties) {
         super(properties);
         client = ClientBuilder.newClient().register(MoxyJsonFeature.class);
-        url = "must set from properties ...";
+        url = properties.getProperty("url", "http://localhost:4400");
     }
 
     @Override


### PR DESCRIPTION
When using the Chronos framework a URL has to be provided. Now it will be read from the properties file. If no such value is found under the key "url", "http://localhost:4400" is used. This appears to be the default URL for Chronos.