### PR TITLE
Introduces a third state for tasks ('2' -> running).

### DIFF
--- a/JobProxyChronos/src/main/java/de/unibi/cebitec/bibiserv/jobproxy/chronos/Chronos.java
+++ b/JobProxyChronos/src/main/java/de/unibi/cebitec/bibiserv/jobproxy/chronos/Chronos.java
@@ -239,10 +239,16 @@ public class Chronos extends JobProxyInterface {
         //transform to jobproxy state
         List<State> jobProxyStates = chronosJobs.stream().map(chronosState -> {
             State state = chronosState.getState();
-            if (map.get(state.getId()).getLastExit().equals("failure")) {
-                state.setCode("1");
-            } else {
-                state.setCode("0");
+            String lastExitState = map.get(state.getId()).getLastExit();
+            switch(lastExitState) {
+                case "failure":
+                    state.setCode("1");
+                    break;
+                case "success":
+                    state.setCode("0");
+                    break;
+                default:
+                    state.setCode("2");
             }
             return state;
         }).collect(toList());


### PR DESCRIPTION
Maps the task's state as a ternary state (failure, success, running) to appropriately track the task. 'failure' and 'success' are handled as before, anything else is considered 'running'.